### PR TITLE
Implement docker multi-stage build to reduce final image size

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -3542,10 +3542,9 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "optional": true
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "mqtt": {
       "version": "4.3.7",

--- a/app/package.json
+++ b/app/package.json
@@ -27,6 +27,7 @@
     "async-mqtt": "2.6.3",
     "bunyan": "1.8.15",
     "deep-equal": "2.0.5",
+    "moment": "^2.29.4",
     "serialport": "9.2.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello @fmartinou,

I made a quick PR to implement docker multi-stage build on your Dockerfile to reduce the final image size. 
Now the final image size don't have linux-headers and other builds deps.

It seems to work well on my raspberry running my production. 

I had to add moment as deps because it's an optional deps for bunyan (I disable optional deps on npm install) and it is required for bunyan with -L flag

Before multi stage, image on my raspberry is : **352.4 MB**
After multi stage, image on my raspberry is **116.7 MB**



