### PR TITLE
Fix inconsistent hass configuration when processing incomplete frames

### DIFF
--- a/app/mqtt/hass.js
+++ b/app/mqtt/hass.js
@@ -32,13 +32,12 @@ function getValueTemplate({ label, idLabel }) {
  * Publish Configuration for home-assistant discovery.
  * @param client
  * @param id
- * @param frame
  * @param teleinfoService
  */
 async function publishConfigurationForHassDiscovery({
-    client, id, frame, teleinfoService,
+    client, id, teleinfoService,
 }) {
-    const promises = Object.keys(frame).map(async (label) => {
+    const promises = teleinfoService.getLabels().map(async (label) => {
         const discoveryTopic = `${hassDiscoveryPrefix}/sensor/${mqttBaseTopic}/${id}_${label.toLowerCase()}/config`;
         log.info(`Publish configuration for tag ${label} for discovery to topic [${discoveryTopic}]`);
         const stateTopic = getFrameTopic(id);

--- a/app/mqtt/hass.test.js
+++ b/app/mqtt/hass.test.js
@@ -1,18 +1,6 @@
 const hass = require('./hass');
 const HistoryTicMode = require('../teleinfo/history/HistoryTicMode');
 
-const sample = {
-    ADCO: { raw: '012345678912', value: 12345678912 },
-    OPTARIF: { raw: 'BASE', value: 'BASE' },
-    ISOUSC: { raw: '45', value: 45 },
-    BASE: { raw: '022304568', value: 22304568 },
-    PTEC: { raw: 'TH..', value: 'TH' },
-    IINST: { raw: '003', value: 3 },
-    IMAX: { raw: '090', value: 90 },
-    PAPP: { raw: '00720', value: 720 },
-    HHPHC: { raw: 'A', value: 'A' },
-};
-
 test('publishConfigurationForDiscovery should be called as expected', async () => {
     const mqttClientMock = {
         publish: jest.fn(() => {
@@ -21,10 +9,10 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
     await hass.publishConfigurationForHassDiscovery({
         client: mqttClientMock,
         id: '012345678912',
-        frame: sample,
         teleinfoService: new HistoryTicMode(),
     });
-    expect(mqttClientMock.publish).toHaveBeenCalledTimes(9);
+    expect(mqttClientMock.publish).toHaveBeenCalledTimes(34);
+
     expect(mqttClientMock.publish).toHaveBeenNthCalledWith(1, 'homeassistant/sensor/teleinfo/012345678912_adco/config', JSON.stringify({
         unique_id: 'teleinfo_012345678912_ADCO',
         name: 'Teleinfo 012345678912 ADCO',
@@ -39,11 +27,13 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(2, 'homeassistant/sensor/teleinfo/012345678912_optarif/config', JSON.stringify({
-        unique_id: 'teleinfo_012345678912_OPTARIF',
-        name: 'Teleinfo 012345678912 OPTARIF',
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(2, 'homeassistant/sensor/teleinfo/012345678912_adir1/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_ADIR1',
+        name: 'Teleinfo 012345678912 ADIR1',
         state_topic: 'teleinfo/012345678912',
-        value_template: '{% if \'OPTARIF\' in value_json %}{{ value_json.OPTARIF.value }}{% else %}\'\'{% endif %}',
+        device_class: 'current',
+        value_template: '{% if \'ADIR1\' in value_json %}{{ value_json.ADIR1.value }}{% else %}\'\'{% endif %}',
         device: {
             identifiers: [
                 '012345678912',
@@ -53,12 +43,45 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(3, 'homeassistant/sensor/teleinfo/012345678912_isousc/config', JSON.stringify({
-        unique_id: 'teleinfo_012345678912_ISOUSC',
-        name: 'Teleinfo 012345678912 ISOUSC',
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(3, 'homeassistant/sensor/teleinfo/012345678912_adir2/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_ADIR2',
+        name: 'Teleinfo 012345678912 ADIR2',
         state_topic: 'teleinfo/012345678912',
         device_class: 'current',
-        value_template: '{% if \'ISOUSC\' in value_json %}{{ value_json.ISOUSC.value }}{% else %}\'\'{% endif %}',
+        value_template: '{% if \'ADIR2\' in value_json %}{{ value_json.ADIR2.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(4, 'homeassistant/sensor/teleinfo/012345678912_adir3/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_ADIR3',
+        name: 'Teleinfo 012345678912 ADIR3',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'current',
+        value_template: '{% if \'ADIR3\' in value_json %}{{ value_json.ADIR3.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(5, 'homeassistant/sensor/teleinfo/012345678912_adps/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_ADPS',
+        name: 'Teleinfo 012345678912 ADPS',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'current',
+        value_template: '{% if \'ADPS\' in value_json %}{{ value_json.ADPS.value }}{% else %}\'\'{% endif %}',
         unit_of_measurement: 'A',
         device: {
             identifiers: [
@@ -69,7 +92,8 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(4, 'homeassistant/sensor/teleinfo/012345678912_base/config', JSON.stringify({
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(6, 'homeassistant/sensor/teleinfo/012345678912_base/config', JSON.stringify({
         unique_id: 'teleinfo_012345678912_BASE',
         name: 'Teleinfo 012345678912 BASE',
         state_topic: 'teleinfo/012345678912',
@@ -86,11 +110,15 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(5, 'homeassistant/sensor/teleinfo/012345678912_ptec/config', JSON.stringify({
-        unique_id: 'teleinfo_012345678912_PTEC',
-        name: 'Teleinfo 012345678912 PTEC',
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(7, 'homeassistant/sensor/teleinfo/012345678912_bbrhcjb/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_BBRHCJB',
+        name: 'Teleinfo 012345678912 BBRHCJB',
         state_topic: 'teleinfo/012345678912',
-        value_template: '{% if \'PTEC\' in value_json %}{{ value_json.PTEC.value }}{% else %}\'\'{% endif %}',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'BBRHCJB\' in value_json %}{{ value_json.BBRHCJB.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
         device: {
             identifiers: [
                 '012345678912',
@@ -100,7 +128,200 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(6, 'homeassistant/sensor/teleinfo/012345678912_iinst/config', JSON.stringify({
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(8, 'homeassistant/sensor/teleinfo/012345678912_bbrhcjr/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_BBRHCJR',
+        name: 'Teleinfo 012345678912 BBRHCJR',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'BBRHCJR\' in value_json %}{{ value_json.BBRHCJR.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(9, 'homeassistant/sensor/teleinfo/012345678912_bbrhcjw/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_BBRHCJW',
+        name: 'Teleinfo 012345678912 BBRHCJW',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'BBRHCJW\' in value_json %}{{ value_json.BBRHCJW.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(10, 'homeassistant/sensor/teleinfo/012345678912_bbrhpjb/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_BBRHPJB',
+        name: 'Teleinfo 012345678912 BBRHPJB',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'BBRHPJB\' in value_json %}{{ value_json.BBRHPJB.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(11, 'homeassistant/sensor/teleinfo/012345678912_bbrhpjr/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_BBRHPJR',
+        name: 'Teleinfo 012345678912 BBRHPJR',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'BBRHPJR\' in value_json %}{{ value_json.BBRHPJR.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(12, 'homeassistant/sensor/teleinfo/012345678912_bbrhpjw/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_BBRHPJW',
+        name: 'Teleinfo 012345678912 BBRHPJW',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'BBRHPJW\' in value_json %}{{ value_json.BBRHPJW.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(13, 'homeassistant/sensor/teleinfo/012345678912_demain/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_DEMAIN',
+        name: 'Teleinfo 012345678912 DEMAIN',
+        state_topic: 'teleinfo/012345678912',
+        value_template: '{% if \'DEMAIN\' in value_json %}{{ value_json.DEMAIN.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(14, 'homeassistant/sensor/teleinfo/012345678912_ejphn/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_EJPHN',
+        name: 'Teleinfo 012345678912 EJPHN',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'EJPHN\' in value_json %}{{ value_json.EJPHN.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(15, 'homeassistant/sensor/teleinfo/012345678912_ejphpm/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_EJPHPM',
+        name: 'Teleinfo 012345678912 EJPHPM',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'EJPHPM\' in value_json %}{{ value_json.EJPHPM.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(16, 'homeassistant/sensor/teleinfo/012345678912_hchc/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_HCHC',
+        name: 'Teleinfo 012345678912 HCHC',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'HCHC\' in value_json %}{{ value_json.HCHC.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(17, 'homeassistant/sensor/teleinfo/012345678912_hchp/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_HCHP',
+        name: 'Teleinfo 012345678912 HCHP',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'total_increasing',
+        device_class: 'energy',
+        value_template: '{% if \'HCHP\' in value_json %}{{ value_json.HCHP.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'Wh',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(18, 'homeassistant/sensor/teleinfo/012345678912_hhphc/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_HHPHC',
+        name: 'Teleinfo 012345678912 HHPHC',
+        state_topic: 'teleinfo/012345678912',
+        value_template: '{% if \'HHPHC\' in value_json %}{{ value_json.HHPHC.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(19, 'homeassistant/sensor/teleinfo/012345678912_iinst/config', JSON.stringify({
         unique_id: 'teleinfo_012345678912_IINST',
         name: 'Teleinfo 012345678912 IINST',
         state_topic: 'teleinfo/012345678912',
@@ -117,7 +338,62 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(7, 'homeassistant/sensor/teleinfo/012345678912_imax/config', JSON.stringify({
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(20, 'homeassistant/sensor/teleinfo/012345678912_iinst1/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_IINST1',
+        name: 'Teleinfo 012345678912 IINST1',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'measurement',
+        device_class: 'current',
+        value_template: '{% if \'IINST1\' in value_json %}{{ value_json.IINST1.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(21, 'homeassistant/sensor/teleinfo/012345678912_iinst2/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_IINST2',
+        name: 'Teleinfo 012345678912 IINST2',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'measurement',
+        device_class: 'current',
+        value_template: '{% if \'IINST2\' in value_json %}{{ value_json.IINST2.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(22, 'homeassistant/sensor/teleinfo/012345678912_iinst3/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_IINST3',
+        name: 'Teleinfo 012345678912 IINST3',
+        state_topic: 'teleinfo/012345678912',
+        state_class: 'measurement',
+        device_class: 'current',
+        value_template: '{% if \'IINST3\' in value_json %}{{ value_json.IINST3.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(23, 'homeassistant/sensor/teleinfo/012345678912_imax/config', JSON.stringify({
         unique_id: 'teleinfo_012345678912_IMAX',
         name: 'Teleinfo 012345678912 IMAX',
         state_topic: 'teleinfo/012345678912',
@@ -133,7 +409,106 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(8, 'homeassistant/sensor/teleinfo/012345678912_papp/config', JSON.stringify({
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(24, 'homeassistant/sensor/teleinfo/012345678912_imax1/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_IMAX1',
+        name: 'Teleinfo 012345678912 IMAX1',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'current',
+        value_template: '{% if \'IMAX1\' in value_json %}{{ value_json.IMAX1.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(25, 'homeassistant/sensor/teleinfo/012345678912_imax2/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_IMAX2',
+        name: 'Teleinfo 012345678912 IMAX2',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'current',
+        value_template: '{% if \'IMAX2\' in value_json %}{{ value_json.IMAX2.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(26, 'homeassistant/sensor/teleinfo/012345678912_imax3/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_IMAX3',
+        name: 'Teleinfo 012345678912 IMAX3',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'current',
+        value_template: '{% if \'IMAX3\' in value_json %}{{ value_json.IMAX3.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(27, 'homeassistant/sensor/teleinfo/012345678912_isousc/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_ISOUSC',
+        name: 'Teleinfo 012345678912 ISOUSC',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'current',
+        value_template: '{% if \'ISOUSC\' in value_json %}{{ value_json.ISOUSC.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'A',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(28, 'homeassistant/sensor/teleinfo/012345678912_motdetat/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_MOTDETAT',
+        name: 'Teleinfo 012345678912 MOTDETAT',
+        state_topic: 'teleinfo/012345678912',
+        value_template: '{% if \'MOTDETAT\' in value_json %}{{ value_json.MOTDETAT.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(29, 'homeassistant/sensor/teleinfo/012345678912_optarif/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_OPTARIF',
+        name: 'Teleinfo 012345678912 OPTARIF',
+        state_topic: 'teleinfo/012345678912',
+        value_template: '{% if \'OPTARIF\' in value_json %}{{ value_json.OPTARIF.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(30, 'homeassistant/sensor/teleinfo/012345678912_papp/config', JSON.stringify({
         unique_id: 'teleinfo_012345678912_PAPP',
         name: 'Teleinfo 012345678912 PAPP',
         state_topic: 'teleinfo/012345678912',
@@ -150,11 +525,60 @@ test('publishConfigurationForDiscovery should be called as expected', async () =
             name: 'Linky 012345678912',
         },
     }), { retain: true });
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(9, 'homeassistant/sensor/teleinfo/012345678912_hhphc/config', JSON.stringify({
-        unique_id: 'teleinfo_012345678912_HHPHC',
-        name: 'Teleinfo 012345678912 HHPHC',
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(31, 'homeassistant/sensor/teleinfo/012345678912_pejp/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_PEJP',
+        name: 'Teleinfo 012345678912 PEJP',
         state_topic: 'teleinfo/012345678912',
-        value_template: '{% if \'HHPHC\' in value_json %}{{ value_json.HHPHC.value }}{% else %}\'\'{% endif %}',
+        value_template: '{% if \'PEJP\' in value_json %}{{ value_json.PEJP.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'min',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(32, 'homeassistant/sensor/teleinfo/012345678912_pmax/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_PMAX',
+        name: 'Teleinfo 012345678912 PMAX',
+        state_topic: 'teleinfo/012345678912',
+        device_class: 'power',
+        value_template: '{% if \'PMAX\' in value_json %}{{ value_json.PMAX.value }}{% else %}\'\'{% endif %}',
+        unit_of_measurement: 'W',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(33, 'homeassistant/sensor/teleinfo/012345678912_ppot/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_PPOT',
+        name: 'Teleinfo 012345678912 PPOT',
+        state_topic: 'teleinfo/012345678912',
+        value_template: '{% if \'PPOT\' in value_json %}{{ value_json.PPOT.value }}{% else %}\'\'{% endif %}',
+        device: {
+            identifiers: [
+                '012345678912',
+            ],
+            manufacturer: 'Enedis',
+            model: 'linky_012345678912',
+            name: 'Linky 012345678912',
+        },
+    }), { retain: true });
+
+    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(34, 'homeassistant/sensor/teleinfo/012345678912_ptec/config', JSON.stringify({
+        unique_id: 'teleinfo_012345678912_PTEC',
+        name: 'Teleinfo 012345678912 PTEC',
+        state_topic: 'teleinfo/012345678912',
+        value_template: '{% if \'PTEC\' in value_json %}{{ value_json.PTEC.value }}{% else %}\'\'{% endif %}',
         device: {
             identifiers: [
                 '012345678912',

--- a/app/mqtt/index.js
+++ b/app/mqtt/index.js
@@ -82,7 +82,6 @@ async function publishFrame({ frame, teleinfoService }) {
                 await publishConfigurationForHassDiscovery({
                     client,
                     id,
-                    frame,
                     teleinfoService,
                 });
                 discoveryConfigurationPublished = true;

--- a/app/teleinfo/TicMode.js
+++ b/app/teleinfo/TicMode.js
@@ -246,6 +246,14 @@ class TicMode {
     }
 
     /**
+     * Get the list of labels managed by this TicMode
+     */
+    /* eslint-disable class-methods-use-this */
+    getLabels() {
+        throw new Error('getMode must be overridden');
+    }
+
+    /**
      * Get baud rate.
      */
     /* eslint-disable class-methods-use-this */

--- a/app/teleinfo/history/HistoryTicMode.js
+++ b/app/teleinfo/history/HistoryTicMode.js
@@ -4,6 +4,43 @@ class HistoryTicMode extends TicMode {
     // eslint-disable-next-line
     static TIC_MODE = 'history';
 
+    labels = [
+        'ADCO',
+        'ADIR1',
+        'ADIR2',
+        'ADIR3',
+        'ADPS',
+        'BASE',
+        'BBRHCJB',
+        'BBRHCJR',
+        'BBRHCJW',
+        'BBRHPJB',
+        'BBRHPJR',
+        'BBRHPJW',
+        'DEMAIN',
+        'EJPHN',
+        'EJPHPM',
+        'HCHC',
+        'HCHP',
+        'HHPHC',
+        'IINST',
+        'IINST1',
+        'IINST2',
+        'IINST3',
+        'IMAX',
+        'IMAX1',
+        'IMAX2',
+        'IMAX3',
+        'ISOUSC',
+        'MOTDETAT',
+        'OPTARIF',
+        'PAPP',
+        'PEJP',
+        'PMAX',
+        'PPOT',
+        'PTEC',
+    ];
+
     /**
      * Does ticMode match history?
      */
@@ -26,6 +63,13 @@ class HistoryTicMode extends TicMode {
     /* eslint-disable class-methods-use-this */
     getBaudRate() {
         return 1200;
+    }
+
+    /**
+     * Get the list of labels managed by this TicMode
+     */
+    getLabels() {
+        return this.labels;
     }
 
     /**

--- a/app/teleinfo/standard/StandardTicMode.js
+++ b/app/teleinfo/standard/StandardTicMode.js
@@ -3,6 +3,80 @@ const TicMode = require('../TicMode');
 class StandardTicMode extends TicMode {
     static TIC_MODE = 'standard';
 
+    labels = [
+        'ADSC',
+        'CCAIN',
+        'CCAIN-1',
+        'CCASN',
+        'CCASN-1',
+        'DATE',
+        'DPM1',
+        'DPM2',
+        'DPM3',
+        'EAIT',
+        'EASD01',
+        'EASD02',
+        'EASD03',
+        'EASD04',
+        'EASF01',
+        'EASF02',
+        'EASF03',
+        'EASF04',
+        'EASF05',
+        'EASF06',
+        'EASF07',
+        'EASF08',
+        'EASF09',
+        'EASF10',
+        'EAST',
+        'ERQ1',
+        'ERQ2',
+        'ERQ3',
+        'ERQ4',
+        'FPM1',
+        'FPM2',
+        'FPM3',
+        'IRMS1',
+        'IRMS2',
+        'IRMS3',
+        'LTARF',
+        'MSG1',
+        'MSG2',
+        'NGTF',
+        'NJOURF',
+        'NJOURF+1',
+        'NTARF',
+        'PCOUP',
+        'PJOURF+1',
+        'PPOINTE',
+        'PREF',
+        'PRM',
+        'RELAIS',
+        'SINSTI',
+        'SINSTS',
+        'SINSTS1',
+        'SINSTS2',
+        'SINSTS3',
+        'SMAXIN',
+        'SMAXIN-1',
+        'SMAXSN',
+        'SMAXSN-1',
+        'SMAXSN1',
+        'SMAXSN1-1',
+        'SMAXSN2',
+        'SMAXSN2-1',
+        'SMAXSN3',
+        'SMAXSN3-1',
+        'STGE',
+        'UMOY1',
+        'UMOY2',
+        'UMOY3',
+        'URMS1',
+        'URMS2',
+        'URMS3',
+        'VTIC',
+    ];
+
     /**
      * Does ticMode match standard?
      */
@@ -24,6 +98,13 @@ class StandardTicMode extends TicMode {
     /* eslint-disable class-methods-use-this */
     getBaudRate() {
         return 9600;
+    }
+
+    /**
+     * Get the list of labels managed by this TicMode
+     */
+    getLabels() {
+        return this.labels;
     }
 
     /**


### PR DESCRIPTION
Hello!

I use teleinfo2mqtt in Standard mode. I noticed a strange behavior with the teleinformation data transmitted to Home Assistant: some values were completely absent (e.g. `SINSTS`), while other data were correctly transmitted and regularly updated. Restarting the teleinfo2mqtt service fixed the problem, but the behavior was rather random and I encountered the same problem with other values.

After a few debugging sessions in teleinfo2mqtt, I realized that there was a lot of interference on my serial link, despite the shielded cable used (the Linky meter is outside my house, more than 30m away).

As a result, **a lot** of values are corrupted. Looking at the frames emitted by the `StandardTicMode` service, I found that they contained between 25 and 40 labels and that I almost never had a "complete frame".

This is not a big deal, as the data is transmitted very regularly. But it is a problem for Hass discovery.
The configuration published on the discoveryTopic is based on the content of the first frame published by the TicMode service. This means that the published configuration is incomplete if the first frame contains corrupted data.

### Proposal

To solve this issue, I propose not to rely on the labels contained in the first frame to publish the configuration. As the exhaustive list of labels is known for each TicMode, I propose to use this list to publish the configuration.

I'm aware that some of the values in the published configuration will not be transmitted by the counter, depending on each individual's situation (e.g. production data). But I don't think it's a problem.

WDYT? I hope I haven't missed an important detail about how Hass discovery works, I'm new to mqtt ^^

(and by the way, thanks for this very useful project!)