### PR TITLE
Add new CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,7 +83,7 @@ jobs:
   build-and-push-image:
     needs: test
     if: ${{ needs.test.result == 'success' }}
-    name: Build ${{ (github.event.action == 'released' || github.event.action == 'prereleased') && 'and push ' || '' }}image for ${{ matrix.platforms }}
+    name: Build ${{ (github.event.action == 'released' || github.event.action == 'prereleased') && 'and push ' || '' }}image for ${{ matrix.platform }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -116,7 +116,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
-          platforms: ${{ matrix.platforms }}
+          platforms: ${{ matrix.platform }}
           tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:develop${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
           build-args: |
             IMAGE_DATE=${{ github.event.repository.updated_at }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
-          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64
+          platforms: linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64
           tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:develop${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
           build-args: |
             IMAGE_DATE=${{ github.event.repository.updated_at }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,6 +102,12 @@ jobs:
         run: |
           echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -117,6 +117,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        if: ${{ secrets.DOCKER_USERNAME != '' }}
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3.3.0
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,27 +59,29 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: context.payload.workflow_run.id,
             });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "coverage"
             })[0];
-            var download = await github.rest.actions.downloadArtifact({
+            let download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
                archive_format: 'zip',
             });
-            var fs = require('fs');
-            fs.writeFileSync('${{ github.workspace }}/coverage.zip', Buffer.from(download.data));
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            fs.writeFileSync(path.join(temp, 'coverage.zip'), Buffer.from(download.data));
       - name: Unzip coverage
-        run: |
-          mkdir coverage
-          cd coverage
-          unzip ../coverage.zip
+        run: unzip coverage.zip -d coverage
       - name: Code Climate test reporter
         env:
 #          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-          working-directory: ./app/package-lock.json
+          cache-dependency-path: ./app/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: ./app
+    name: test/node ${{ matrix.node-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,6 +35,34 @@ jobs:
 
       - name: Run UT
         run: npm test
+
+  coverage:
+    needs: [ test ]
+    if: ${{ needs.test.result == 'success' }}
+    name: coverage
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./app
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./app/package-lock.json
+
+      - run: npm install -g yarn
+      - run: yarn install
+      - run: yarn build
+      - uses: paambaati/codeclimate-action@v2.2.4
+        env:
+          CC_TEST_REPORTER_ID: 5167fc209c026a59fa2f9e21c7e21efa2ce09989a62ca8bc775f2240d8b9f662
+        with:
+          coverageCommand: yarn coverage
 
   build-and-push-image:
     needs: test
@@ -71,7 +100,7 @@ jobs:
           context: .
           push: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
           platforms: ${{ matrix.platforms }}
-          tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:latest-dev${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
+          tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:develop${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
           build-args: |
             IMAGE_DATE=${{ github.event.repository.updated_at }}
             IMAGE_REF=$(git rev-parse --short HEAD)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,16 +10,31 @@ env:
   NODE_VERSION_NEXT: 22
 
 jobs:
+
+  define-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      node-version: ${{ steps.node-version.outputs.node-version }}
+      node-version-next: ${{ steps.node-version.outputs.node-version-next }}
+    steps:
+      - name: Define Node versions
+        id: node-version
+        run: |
+          echo 'node-version=["$NODE_VERSION"]' >> "$GITHUB_OUTPUT"
+      - name: Define next Node versions
+        id: node-version-next
+        run: |
+          echo 'node-version-next=["$NODE_VERSION_NEXT"]' >> "$GITHUB_OUTPUT"
   test:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
       matrix:
-        node-version: [ "${{ env.NODE_VERSION }}" ]
+        node-version: ${{ fromJSON(needs.define-matrix.outputs.node-version) }}
         experimental: [ false ]
         include:
-          - node-version: "${{ env.NODE_VERSION_NEXT }}"
+          - node-version: ${{ fromJSON(needs.define-matrix.outputs.node-version-next) }}
             experimental: true
     defaults:
       run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Define next Node versions
         id: node-version-next
         run: |
-          echo "node-version-next=[ $NODE_VERSION_NEXT ]" >> "$GITHUB_OUTPUT"
+          echo "node-version-next=$NODE_VERSION_NEXT" >> "$GITHUB_OUTPUT"
   test:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: ${{ NODE_VERSION }}
+        node-version: [ "${{ env.NODE_VERSION }}" ]
         experimental: [ false ]
         include:
-          - node-version: ${{ NODE_VERSION_NEXT }}
+          - node-version: "${{ env.NODE_VERSION_NEXT }}"
             experimental: true
     defaults:
       run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: ./app/package-lock.json
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
     defaults:
       run:
         working-directory: ./app
-    name: test/node ${{ matrix.node-version }}
+    name: Test with node ${{ matrix.node-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
   coverage:
     needs: [ test ]
     if: ${{ needs.test.result == 'success' }}
-    name: coverage
+    name: Test Coverage
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -47,26 +47,51 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: ./app/package-lock.json
-
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn build
-      - uses: paambaati/codeclimate-action@v9.0.0
+      - name: Set up Code Climate test reporter
         env:
+#          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           CC_TEST_REPORTER_ID: 5167fc209c026a59fa2f9e21c7e21efa2ce09989a62ca8bc775f2240d8b9f662
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+      - name: Download coverage
+        uses: actions/github-script@v7
         with:
-          coverageCommand: yarn coverage
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/coverage.zip', Buffer.from(download.data));
+      - name: Unzip coverage
+        run: |
+          mkdir coverage
+          cd coverage
+          unzip ../coverage.zip
+      - name: Code Climate test reporter
+        env:
+#          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          CC_TEST_REPORTER_ID: 5167fc209c026a59fa2f9e21c7e21efa2ce09989a62ca8bc775f2240d8b9f662
+          GIT_BRANCH: ${{github.event.workflow_run.head_branch }}
+          GIT_COMMIT_SHA: ${{github.event.workflow_run.head_commit.id }}
+        run: ./cc-test-reporter after-build -t lcov --debug --exit-code $?
 
   build-and-push-image:
     needs: test
     if: ${{ needs.test.result == 'success' }}
+    name: Build ${{ (github.event.action == 'released' || github.event.action == 'prereleased') && 'and push ' || '' }}image for ${{ matrix.platforms }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,6 +73,7 @@ jobs:
           platforms: ${{ matrix.platforms }}
           tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:latest-dev${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
           build-args: |
-            BUILD_DATE=${{ github.event.repository.updated_at }}
-            BUILD_REF=$(git rev-parse --short HEAD)
-            BUILD_VERSION=${{ github.ref_name }}
+            IMAGE_DATE=${{ github.event.repository.updated_at }}
+            IMAGE_REF=$(git rev-parse --short HEAD)
+            IMAGE_VERSION=${{ github.ref_name }}
+            IMAGE_NAME=${{ env.REPO }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,10 +59,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const ref = context.payload.pull_request ? context.payload.pull_request.head.sha : context.payload.before;
             let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+               run_id: ref,
             });
             let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "coverage"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: ['20.x', '22.x']
+        node-version: [ 20, 22 ]
     defaults:
       run:
         working-directory: ./app
@@ -24,14 +24,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-    #  - run: npm config set package-lock true
-    #  - run: echo 'package-lock=true'>> .npmrc
-    #  - run: npm install -g npm@latest
-    #  - run: npm i -g npm-upgrade
+          working-directory: ./app/package-lock.json
 
       - name: Install dependencies
         run: npm ci
- #     - run: npm run build --if-present
 
       - name: Run Linter
         run: npm run lint

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
+    needs:
+    - define-matrix
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -118,7 +118,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKER_USERNAME != '' }}
+        continue-on-error: true
         uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
-          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
+          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64
           tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:develop${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
           build-args: |
             IMAGE_DATE=${{ github.event.repository.updated_at }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
       - run: npm install -g yarn
       - run: yarn install
       - run: yarn build
-      - uses: paambaati/codeclimate-action@v2.2.4
+      - uses: paambaati/codeclimate-action@v9.0.0
         env:
           CC_TEST_REPORTER_ID: 5167fc209c026a59fa2f9e21c7e21efa2ce09989a62ca8bc775f2240d8b9f662
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,7 +62,7 @@ jobs:
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
+               run_id: context.payload.workflow_run.id,
             });
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "coverage"
@@ -74,7 +74,7 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/coverage.zip', Buffer.from(download.data));
+            fs.writeFileSync('${{ github.workspace }}/coverage.zip', Buffer.from(download.data));
       - name: Unzip coverage
         run: |
           mkdir coverage

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [ $NODE_VERSION ]
+        node-version: ${{ NODE_VERSION }}
         experimental: [ false ]
         include:
-          - node-version: $NODE_VERSION_NEXT
+          - node-version: ${{ NODE_VERSION_NEXT }}
             experimental: true
     defaults:
       run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       node-version: ${{ steps.node-version.outputs.node-version }}
-      node-version-next: ${{ steps.node-version.outputs.node-version-next }}
+      node-version-next: ${{ steps.node-version-next.outputs.node-version-next }}
     steps:
       - name: Define Node versions
         id: node-version

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,34 +55,23 @@ jobs:
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
-      - name: Download coverage
-        uses: actions/github-script@v7
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
         with:
-          script: |
-            const ref = context.payload.pull_request ? context.payload.pull_request.head.sha : context.payload.before;
-            let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ref,
-            });
-            let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "coverage"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            const fs = require('fs');
-            const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
-            if (!fs.existsSync(temp)){
-              fs.mkdirSync(temp);
-            }
-            fs.writeFileSync(path.join(temp, 'coverage.zip'), Buffer.from(download.data));
-      - name: Unzip coverage
-        run: unzip coverage.zip -d coverage
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: ./app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Linter
+        run: npm run lint
+
+      - name: Run UT
+        run: npm test
+
       - name: Code Climate test reporter
         env:
 #          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,17 +83,8 @@ jobs:
   build-and-push-image:
     needs: test
     if: ${{ needs.test.result == 'success' }}
-    name: Build ${{ (github.event.action == 'released' || github.event.action == 'prereleased') && 'and push ' || '' }}image for ${{ matrix.platform }}
+    name: Build ${{ (github.event.action == 'released' || github.event.action == 'prereleased') && 'and push ' || '' }}image
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/386
-          - linux/amd64
-          - linux/arm/v6
-          - linux/arm/v7
-          - linux/arm64/v8
     permissions:
       packages: write
     steps:
@@ -116,7 +107,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
-          platforms: ${{ matrix.platform }}
+          platforms: linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64/v8
           tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:develop${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
           build-args: |
             IMAGE_DATE=${{ github.event.repository.updated_at }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,82 @@
+name: App-build-test-push
+
+on:
+  push:
+  release:
+    types: [released, prereleased]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: ['20.x', '22.x']
+    defaults:
+      run:
+        working-directory: ./app
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+    #  - run: npm config set package-lock true
+    #  - run: echo 'package-lock=true'>> .npmrc
+    #  - run: npm install -g npm@latest
+    #  - run: npm i -g npm-upgrade
+
+      - name: Install dependencies
+        run: npm ci
+ #     - run: npm run build --if-present
+
+      - name: Run Linter
+        run: npm run lint
+
+      - name: Run UT
+        run: npm test
+
+  build-and-push-image:
+    needs: test
+    if: ${{ needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/386
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64/v8
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase repo name
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event.action == 'released' || github.event.action == 'prereleased' }}
+          platforms: ${{ matrix.platforms }}
+          tags: ghcr.io/${{ env.REPO }}:${{ github.ref_name }},ghcr.io/${{ env.REPO }}:latest-dev${{ github.event.action == 'released' && format(',ghcr.io/{0}:latest', env.REPO) || '' }}
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            BUILD_REF=$(git rev-parse --short HEAD)
+            BUILD_VERSION=${{ github.ref_name }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,13 +5,22 @@ on:
   release:
     types: [released, prereleased]
 
+env:
+  NODE_VERSION: 20
+  NODE_VERSION_NEXT: 22
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
       matrix:
-        node-version: [ 20, 22 ]
+        node-version: [ $NODE_VERSION ]
+        experimental: [ false ]
+        include:
+          - node-version: $NODE_VERSION_NEXT
+            experimental: true
     defaults:
       run:
         working-directory: ./app
@@ -59,7 +68,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: $NODE_VERSION
           cache: 'npm'
           cache-dependency-path: ./app/package-lock.json
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,11 +20,11 @@ jobs:
       - name: Define Node versions
         id: node-version
         run: |
-          echo 'node-version=["$NODE_VERSION"]' >> "$GITHUB_OUTPUT"
+          echo "node-version=[ $NODE_VERSION ]" >> "$GITHUB_OUTPUT"
       - name: Define next Node versions
         id: node-version-next
         run: |
-          echo 'node-version-next=["$NODE_VERSION_NEXT"]' >> "$GITHUB_OUTPUT"
+          echo "node-version-next=[ $NODE_VERSION_NEXT ]" >> "$GITHUB_OUTPUT"
   test:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ![Docker pulls](https://img.shields.io/docker/pulls/fmartinou/teleinfo2mqtt)
 ![License](https://img.shields.io/github/license/fmartinou/teleinfo2mqtt)
-![Travis](https://img.shields.io/travis/fmartinou/teleinfo2mqtt/master)
+[![CI](https://github.com/fmartinou/teleinfo2mqtt/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/fmartinou/teleinfo2mqtt/actions/workflows/docker-publish.yml)
 ![Maintainability](https://img.shields.io/codeclimate/maintainability/fmartinou/teleinfo2mqtt)
 ![Coverage](https://img.shields.io/codeclimate/coverage/fmartinou/teleinfo2mqtt)
+![GitHub release](https://img.shields.io/github/release/fmartinou/teleinfo2mqtt.svg)
 
 ![](docs/teleinfo2mqtt-logo-250.png)
 


### PR DESCRIPTION
As the current CI is having some issues, I took the liberty to rewrite the CI using GitHub Actions.

I tried to make it to the same level you had with Travis.

But if you don't like it, I have no problem with trashing it.

Features:
* Automatic test, coverage and build of the Docker image at pushes and (pre-)releases
* Test run on both current Node version and next (the later is allowed to fail)
* Push Docker images only on (pre-)releases.
* Push Docker images to GitHub packages and Docker Hub (if credentials provided)
* Move `CC_TEST_REPORTER_ID` to secrets